### PR TITLE
gitlab markdown fix

### DIFF
--- a/markdown.py
+++ b/markdown.py
@@ -65,7 +65,7 @@ def output_markdown_table(stream, header, rows):
     stream.write(" |\n")
     # Seperator
     stream.write("| ")
-    stream.write(" | ".join(map(lambda x: '-'*len(x), header)))
+    stream.write(" | ".join(map(lambda x: '-'*min(len(x),3), header)))
     stream.write(" |\n")
     # Rows
     for row in rows:


### PR DESCRIPTION
Our gitlab dont like IP with only two minus signs as table markdown. It must at least 3 minus signs.